### PR TITLE
Fix Insecure Loading of Cover Art

### DIFF
--- a/spotcommander/nowplaying.php
+++ b/spotcommander/nowplaying.php
@@ -55,7 +55,7 @@ if(spotify_is_running())
 		$album = (empty($nowplaying['album'])) ? $album : $nowplaying['album'];
 		$uri = ($is_local) ? preg_replace('/:\d*$/', '', $nowplaying['url']) . ':' : url_to_uri($nowplaying['url']);
 		$length = convert_length($nowplaying['length'], 'mc');
-		$cover_art = (empty($nowplaying['artUrl'])) ? 'img/no-cover-art-640.png?' . project_serial : str_replace(array('https', 'open.spotify.com', '/thumb/'), array('http', 'i.scdn.co', '/image/'), $nowplaying['artUrl']);
+		$cover_art = (empty($nowplaying['artUrl'])) ? 'img/no-cover-art-640.png?' . project_serial : str_replace(array('http', 'open.spotify.com', '/thumb/'), array('https', 'i.scdn.co', '/image/'), $nowplaying['artUrl']);
 		$released = (empty($nowplaying['contentCreated'])) ? 'Unknown' : substr($nowplaying['contentCreated'], 0, 4);
 		$popularity = (empty($nowplaying['autoRating'])) ? 'Unknown' : convert_popularity($nowplaying['autoRating']);
 


### PR DESCRIPTION
Hi,

I've been a longtime fan of SpotCommander and I recently configured Apache to use SSL. 
While testing, my web browser noticed cover art was loaded insecurely. 

When I looked into the relevant line of code, I noticed that the `artUrl` url starts with "http". This line of code was expecting "https", not "http". 

So, I fixed the line and my web browser showed SpotCommander was secure after cover art loaded.

Thanks
